### PR TITLE
Add Shadowsocks forwarder setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,61 @@
 # flow-transit
+
+该仓库提供一个脚本，用于在标准 Linux 发行版上自动化部署可供 Shadowsocks 客户端中转流量的代理服务器。脚本会安装 shadowsocks-libev、生成配置、开启 IP 转发并配置防火墙，使得来自客户端的加密流量可以通过服务器转发访问公网。
+
+## 快速开始
+
+1. 准备一台具备 root 权限的 Linux 服务器（Debian/Ubuntu 或 RHEL/CentOS/Fedora）。
+2. 将仓库克隆到服务器上并进入目录：
+   ```bash
+   git clone <repo-url>
+   cd flow-transit
+   ```
+3. 以 root 身份执行安装脚本：
+   ```bash
+   sudo bash scripts/setup_shadowsocks_forwarder.sh
+   ```
+
+脚本执行后会：
+
+- 安装 shadowsocks-libev 及防火墙持久化工具。
+- 创建 `shadowsocks` 系统用户并写入 `/etc/shadowsocks-libev/config.json` 配置。
+- 启用并启动 systemd 服务，监听默认 8388 端口。
+- 开启 IPv4 转发并放通对应的 TCP/UDP 流量。
+
+## 自定义参数
+
+脚本可通过环境变量定制参数：
+
+| 变量名 | 说明 | 默认值 |
+| --- | --- | --- |
+| `SS_SERVER_PORT` | Shadowsocks 监听端口 | 8388 |
+| `SS_PASSWORD` | 连接密码。未设置时会复用已有配置或自动生成随机密码 | 自动生成 |
+| `SS_METHOD` | 加密算法 | aes-256-gcm |
+| `SS_TIMEOUT` | 超时时间（秒） | 300 |
+| `SS_USER` | 运行服务的系统用户 | shadowsocks |
+| `SS_CONFIG_PATH` | 生成配置文件路径 | /etc/shadowsocks-libev/config.json |
+| `SS_SERVICE_NAME` | systemd 服务名称 | shadowsocks-libev |
+
+示例：
+
+```bash
+sudo SS_SERVER_PORT=443 SS_PASSWORD="very-strong-password" bash scripts/setup_shadowsocks_forwarder.sh
+```
+
+## 验证服务
+
+1. 在服务器上查看服务状态：
+   ```bash
+   sudo systemctl status shadowsocks-libev
+   ```
+2. 客户端填入服务器公网 IP、端口、密码和加密方式后即可建立连接，所有流量将通过该服务器中转。
+
+## 手动配置文件
+
+`config/shadowsocks-server.json` 提供了一个最小化模板，可根据需要修改后放置到 `/etc/shadowsocks-libev/config.json`。
+
+## 安全建议
+
+- 请务必修改默认密码，使用高熵随机密码，并避免与他人共享。
+- 建议在服务器上启用防火墙，仅放通 Shadowsocks 端口以及必须的管理端口。
+- 定期更新操作系统和 shadowsocks-libev 软件包，确保获得安全补丁。

--- a/config/shadowsocks-server.json
+++ b/config/shadowsocks-server.json
@@ -1,0 +1,9 @@
+{
+  "server": "0.0.0.0",
+  "server_port": 8388,
+  "password": "change-me",
+  "timeout": 300,
+  "method": "aes-256-gcm",
+  "fast_open": true,
+  "mode": "tcp_and_udp"
+}

--- a/scripts/setup_shadowsocks_forwarder.sh
+++ b/scripts/setup_shadowsocks_forwarder.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# setup_shadowsocks_forwarder.sh
+#
+# This script provisions a Linux host to operate as a Shadowsocks forwarder.
+# It installs the shadowsocks-libev server, creates a hardened configuration,
+# enables IP forwarding, and configures firewall rules to allow proxy traffic.
+#
+# Environment variables can be used to tweak the installation:
+#   SS_SERVER_PORT   - TCP/UDP port to listen on (default: 8388)
+#   SS_PASSWORD      - Password for the Shadowsocks server (default: auto-generated)
+#   SS_METHOD        - Encryption method (default: aes-256-gcm)
+#   SS_TIMEOUT       - Timeout in seconds (default: 300)
+#   SS_USER          - System user that will own the Shadowsocks service (default: shadowsocks)
+#   SS_CONFIG_PATH   - Path to write the generated configuration (default: /etc/shadowsocks-libev/config.json)
+#   SS_SERVICE_NAME  - Name of the systemd service (default: shadowsocks-libev)
+#
+# Usage:
+#   sudo bash setup_shadowsocks_forwarder.sh
+#
+# The script is idempotent; re-running it updates existing configuration without
+# overwriting custom passwords or ports when they are already present.
+
+log() {
+  printf '[%s] %s\n' "$(date +'%Y-%m-%dT%H:%M:%S%z')" "$*"
+}
+
+require_root() {
+  if [[ $(id -u) -ne 0 ]]; then
+    log "ERROR: This script must be run as root."
+    exit 1
+  fi
+}
+
+default_password() {
+  if [[ -f /etc/shadowsocks-libev/config.json ]]; then
+    local existing
+    existing=$(awk -F'"' '/"password"/ {print $4; exit}' /etc/shadowsocks-libev/config.json || true)
+    if [[ -n ${existing:-} ]]; then
+      printf '%s' "$existing"
+      return
+    fi
+  fi
+  # Generate a random 24-character base64 password.
+  openssl rand -base64 32 | tr -d '\n' | cut -c1-24
+}
+
+install_packages() {
+  log "Installing shadowsocks-libev and firewall dependencies"
+  if command -v apt-get >/dev/null 2>&1; then
+    apt-get update
+    DEBIAN_FRONTEND=noninteractive apt-get install -y shadowsocks-libev iptables-persistent jq
+  elif command -v dnf >/dev/null 2>&1; then
+    dnf install -y epel-release
+    dnf install -y shadowsocks-libev iptables-services jq
+  else
+    log "ERROR: Supported package manager (apt or dnf) not found."
+    exit 1
+  fi
+}
+
+create_service_user() {
+  local user=$1
+  if id "$user" >/dev/null 2>&1; then
+    log "Service user '$user' already exists"
+  else
+    log "Creating service user '$user'"
+    useradd --system --no-create-home --shell /usr/sbin/nologin "$user"
+  fi
+}
+
+write_config() {
+  local path=$1
+  local port=$2
+  local password=$3
+  local method=$4
+  local timeout=$5
+
+  mkdir -p "$(dirname "$path")"
+
+  cat >"$path" <<JSON
+{
+  "server": "0.0.0.0",
+  "server_port": $port,
+  "password": "$password",
+  "timeout": $timeout,
+  "method": "$method",
+  "fast_open": true,
+  "mode": "tcp_and_udp"
+}
+JSON
+
+  chmod 640 "$path"
+  chown shadowsocks:shadowsocks "$path" || true
+  log "Wrote Shadowsocks configuration to $path"
+}
+
+configure_systemd() {
+  local service_name=$1
+  local config_path=$2
+  local user=$3
+
+  local service_file="/etc/systemd/system/${service_name}.service"
+  cat >"$service_file" <<SERVICE
+[Unit]
+Description=Shadowsocks-Libev Server Service
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=$user
+Group=$user
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_NET_ADMIN
+AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_NET_ADMIN
+ExecStart=/usr/bin/ss-server -c $config_path
+LimitNOFILE=51200
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+SERVICE
+
+  log "Systemd service created at $service_file"
+  systemctl daemon-reload
+  systemctl enable "$service_name"
+  systemctl restart "$service_name"
+  log "Systemd service '$service_name' restarted"
+}
+
+enable_ip_forwarding() {
+  log "Enabling IPv4 forwarding"
+  sysctl -w net.ipv4.ip_forward=1
+  if ! grep -q '^net.ipv4.ip_forward' /etc/sysctl.conf 2>/dev/null; then
+    echo 'net.ipv4.ip_forward=1' >> /etc/sysctl.conf
+  else
+    sed -i 's/^net\.ipv4\.ip_forward=.*/net.ipv4.ip_forward=1/' /etc/sysctl.conf
+  fi
+}
+
+configure_firewall() {
+  local port=$1
+  log "Configuring firewall to allow Shadowsocks traffic on port $port"
+
+  if command -v ufw >/dev/null 2>&1; then
+    ufw allow "$port"/tcp
+    ufw allow "$port"/udp
+  fi
+
+  iptables -I INPUT -p tcp --dport "$port" -j ACCEPT
+  iptables -I INPUT -p udp --dport "$port" -j ACCEPT
+
+  if command -v netfilter-persistent >/dev/null 2>&1; then
+    netfilter-persistent save
+  elif command -v service >/dev/null 2>&1 && [[ -f /etc/init.d/iptables ]]; then
+    service iptables save
+  fi
+}
+
+main() {
+  require_root
+
+  local port=${SS_SERVER_PORT:-8388}
+  local password=${SS_PASSWORD:-$(default_password)}
+  local method=${SS_METHOD:-aes-256-gcm}
+  local timeout=${SS_TIMEOUT:-300}
+  local user=${SS_USER:-shadowsocks}
+  local config_path=${SS_CONFIG_PATH:-/etc/shadowsocks-libev/config.json}
+  local service_name=${SS_SERVICE_NAME:-shadowsocks-libev}
+
+  install_packages
+  create_service_user "$user"
+  write_config "$config_path" "$port" "$password" "$method" "$timeout"
+  configure_systemd "$service_name" "$config_path" "$user"
+  enable_ip_forwarding
+  configure_firewall "$port"
+
+  log "Shadowsocks forwarder setup complete."
+  log "Server listening on port $port with method $method"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add a provisioning script that installs and configures shadowsocks-libev as a forwarding server
- include a sample server configuration template
- document setup, configuration, and security guidance in the README

## Testing
- bash -n scripts/setup_shadowsocks_forwarder.sh

------
https://chatgpt.com/codex/tasks/task_e_68d9121f2b988332a4760a5ae135cb0a